### PR TITLE
fix: specify: Correct template path in create-new-feature.sh

### DIFF
--- a/.specify/scripts/create-new-feature.sh
+++ b/.specify/scripts/create-new-feature.sh
@@ -75,7 +75,7 @@ FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 mkdir -p "$FEATURE_DIR"
 
 # Copy template if it exists
-TEMPLATE="$REPO_ROOT/templates/spec-template.md"
+TEMPLATE="$REPO_ROOT/.specify/templates/spec-template.md"
 SPEC_FILE="$FEATURE_DIR/spec.md"
 
 if [ -f "$TEMPLATE" ]; then


### PR DESCRIPTION
The template path for 'spec-template.md' was incorrect, leading to a warning and an empty spec file. This commit updates the path to '.specify/templates/spec-template.md'.